### PR TITLE
[UXE-2847] Big number adjusts

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,14 +1,15 @@
 <template>
-  <div class="surface-section py-20">
-    <MenuNavigation/>
-    <div class="px-container w-full flex flex-col gap-20">
-      <div class="flex flex-col w-full gap-20 items-center justify-center py-16 text-color-secondary">
-        Conteúdo
-      </div>
-    </div>
+  <div class="surface-section py-20 px-container">
+    <BigNumbers :items="items" :border="false" />
   </div>
 </template>
 
 <script setup>
-  import MenuNavigation from './templates/menu-navigation-block/index.vue';
+import BigNumbers from './templates/big-numbers/index.vue';
+
+const items = [
+  { titleup:'Até', title: '1,6x', description: 'mais rápido que o Macbook Air (M1)' },
+  { titleup:'Até', title: '13x', description: 'mais rápido que o melhor Macbook Air com Intel' },
+  { titleup:'Até', title: '18h', description: 'de bateria' }
+];
 </script>

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="surface-section py-20 px-container">
-    <BigNumbers :items="items" :border="false" />
+    <BigNumbers :items="items" :border="false" :centralized="false" />
   </div>
 </template>
 

--- a/src/templates/big-numbers/index.vue
+++ b/src/templates/big-numbers/index.vue
@@ -1,7 +1,7 @@
 <template>
   <ul class="flex flex-col md:flex-row items-center md:items-start flex-wrap justify-center rounded px-8 gap-y-6 py-10" :class="[{ 'border surface-border' : border}]">
     <li class="flex flex-col gap-2 justify-evenly min-w-32 md:px-4 max-w-64" v-for="item in items" :key="item.title">
-      <p class="text-base text-color-secondary" 
+      <p class="text-base text-color-secondary font-medium" 
         :class="[
             {'text-center' : centralized },
             {'text-left' : !centralized }
@@ -15,7 +15,7 @@
           ]">
         {{ item.title }}
       </strong>
-      <p class="text-base text-color-secondary"
+      <p class="text-base text-color-secondary font-medium"
       :class="[
             {'text-center' : centralized },
             {'text-left' : !centralized }

--- a/src/templates/big-numbers/index.vue
+++ b/src/templates/big-numbers/index.vue
@@ -1,10 +1,25 @@
 <template>
   <ul class="flex flex-col md:flex-row items-center md:items-start flex-wrap justify-center rounded px-8 gap-y-6 py-10" :class="[{ 'border surface-border' : border}]">
-    <li class="flex flex-col gap-5 justify-evenly min-w-32 md:px-4 max-w-64" v-for="item in items" :key="item.title">
-      <strong class="text-6xl text-center">
+    <li class="flex flex-col gap-2 justify-evenly min-w-32 md:px-4 max-w-64" v-for="item in items" :key="item.title">
+      <p class="text-base text-color-secondary" 
+        :class="[
+            {'text-center' : centralized },
+            {'text-left' : !centralized }
+          ]">
+        {{ item.titleup }}
+      </p>
+      <strong class="text-6xl font-medium"
+      :class="[
+            {'text-center' : centralized },
+            {'text-left' : !centralized }
+          ]">
         {{ item.title }}
       </strong>
-      <p class="text-sm text-color-secondary text-center">
+      <p class="text-base text-color-secondary"
+      :class="[
+            {'text-center' : centralized },
+            {'text-left' : !centralized }
+          ]">
         {{ item.description }}
       </p>
     </li>
@@ -20,6 +35,9 @@ defineProps({
   }
   */
   items: { type: Array, required: true },
+  centralized: {
+    type: Boolean, required: false, default: true
+  },
   border: {
     type: Boolean, required: false, default: true
   }


### PR DESCRIPTION
Conforme solicitado feito um ajuste nos bignumbers para ficarem mais similares a referência da Apple, além de estilo foi adicionado uma prop de texto nova, chamei de titleup e uma prop de estilo nova para centralização.

Referência: 
![image](https://github.com/aziontech/azion-web-kit/assets/44036260/1b303be0-2995-4a6c-83bb-51debbd4ff6e)

Como ficou
![image](https://github.com/aziontech/azion-web-kit/assets/44036260/3dde2fc6-f3f1-4b93-83ad-14f59f68fec6)
